### PR TITLE
Topic/moretoapprobot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,10 @@ on:
   push:
   workflow_dispatch:
 
+env:
+   APP_ID: "Iv23li9aYvt0VW9x4Jhh"
+   PRIVATE_KEY: ${{ secrets.NKDAGILITY_BOT_CLIENTSECRET }}
+
 jobs:
   Setup:
     name: "Setup & Configuration"
@@ -75,6 +79,11 @@ jobs:
     needs: [build, Setup]
     if: ${{ success() && ( needs.Setup.outputs.GitVersion_PreReleaseLabel == 'Preview' || needs.Setup.outputs.GitVersion_PreReleaseLabel == '' ) }}
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.NKDAGILITY_BOT_CLIENTSECRET }}
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
@@ -96,7 +105,7 @@ jobs:
             }
         shell: pwsh
         env:
-         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         GH_TOKEN: ${{ steps.app-token.outputs.token }}
         
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,8 +82,8 @@ jobs:
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.NKDAGILITY_BOT_CLIENTSECRET }}
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
The expected result is that when the release is created it is attributed to the NKDAgility App rather than to github actions. This will allow us to bypass restrictions for manual things.