### PR TITLE
Fix for Query issues in subfolders

### DIFF
--- a/AzureDevOps.WorkItemClone.ConsoleUI/Commands/WorkItemCloneCommand.cs
+++ b/AzureDevOps.WorkItemClone.ConsoleUI/Commands/WorkItemCloneCommand.cs
@@ -234,7 +234,7 @@ namespace AzureDevOps.WorkItemClone.ConsoleUI.Commands
                      { "@projectTags", projectItem.fields.SystemTags },
                      { "@RunName", config.RunName }
                  };
-                 var query = await targetApi.CreateProjectQuery(config.targetQueryTitle, config.targetQuery, queryParameters);
+                 var query = await targetApi.CreateProjectQuery(config.targetQueryTitle, config.targetQueryFolder, config.targetQuery, queryParameters);
                  task7.Increment(1);
                  task7.StopTask();
 

--- a/AzureDevOps.WorkItemClone.ConsoleUI/Commands/WorkItemCloneCommandSettings.cs
+++ b/AzureDevOps.WorkItemClone.ConsoleUI/Commands/WorkItemCloneCommandSettings.cs
@@ -46,17 +46,14 @@ namespace AzureDevOps.WorkItemClone.ConsoleUI.Commands
 
         [Description("The WIQL Query to use. You can use @projectID, @projectTitle, @projectTags to replace data from the project!")]
         [CommandOption("--targetQuery")]
-        [DefaultValue("SELECT [System.Id], [System.WorkItemType], [System.Title], [System.AreaPath],[System.AssignedTo],[System.State] FROM workitems WHERE [System.Parent] = @projectID")]
         public string? targetQuery { get; set; }
 
         [Description("The title to use for the query. You can use @projectID, @projectTitle, @projectTags, @RunName to replace data from the project!")]
         [CommandOption("--targetQueryTitle")]
-        [DefaultValue("Project-@RunName - @projectTitle")]
         public string? targetQueryTitle { get; set; }
 
         [Description("Must already Exist and be in the form 'Shared Queries/Folder1/Folder2'!")]
         [CommandOption("--targetQueryFolder")]
-        [DefaultValue("Shared Queries")]
         public string? targetQueryFolder { get; set; }
 
         //------------------------------------------------

--- a/AzureDevOps.WorkItemClone/AzureDevOpsApi.cs
+++ b/AzureDevOps.WorkItemClone/AzureDevOpsApi.cs
@@ -247,7 +247,7 @@ namespace AzureDevOps.WorkItemClone
             return new(Task.Delay(TimeSpan.FromSeconds(1)));
         }
 
-        public async Task<Query> CreateProjectQuery(string queryName, string wiqlQuery, Dictionary<string, string> parameters)
+        public async Task<Query> CreateProjectQuery(string queryName, string folder, string wiqlQuery, Dictionary<string, string> parameters)
         {
             ///POST https://dev.azure.com/{organization}/{project}/_apis/wit/queries/{query}?api-version=7.1-preview.2
             wiqlQuery = GetQueryString(wiqlQuery, parameters);
@@ -256,10 +256,10 @@ namespace AzureDevOps.WorkItemClone
             {
                 isFolder = false,
                 name = queryName,
-                path = $"Shared Queries/{queryName}",
+                path = $"{folder}/{queryName}",
                 wiql = wiqlQuery
             });
-            string apiCallUrl = $"https://dev.azure.com/{_account}/{_project}/_apis/wit/queries/Shared Queries/?api-version=7.2-preview.2";
+            string apiCallUrl = $"https://dev.azure.com/{_account}/{_project}/_apis/wit/queries/{folder}/?api-version=7.2-preview.2";
             var result = await GetObjectResult<Query>(apiCallUrl, post);
             return result.result;
         }


### PR DESCRIPTION
feat(WorkItemCloneCommand.cs): add targetQueryFolder parameter to Create ProjectQuery method for better query organization

refactor(WorkItemCloneCommandSettings.cs): remove default values for targetQuery, targetQueryTitle, targetQueryFolder to allow more flexibility
refactor(AzureDevOpsApi.cs): modify CreateProjectQuery method to include folder parameter in path and apiCallUrl for better query organization